### PR TITLE
Instructions for Intel oneAPI Setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,9 @@ llvm:
 
 clean-llvm:
 	rm -rf llvm-project/build/
+
+oneapi:
+	echo "blub"
+
+clean-oneapi:
+	echo "blub"

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,3 @@ llvm:
 
 clean-llvm:
 	rm -rf llvm-project/build/
-
-oneapi:
-	echo "blub"
-
-clean-oneapi:
-	echo "blub"

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ make llvm
 
 ### Intel OneAPI Toolchain
 
-tbd
+To install the Intel oneAPI toolchain, please follow the provided instructions on Intel's [website](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit-download.html).

--- a/README.md
+++ b/README.md
@@ -28,4 +28,7 @@ make llvm
 
 ### Intel OneAPI Toolchain
 
-To install the Intel oneAPI toolchain, please follow the provided instructions on Intel's [website](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit-download.html).
+To install the Intel oneAPI toolchain, please follow the provided instructions on Intel's [website](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit-download.html). To be able to compile LULESH with Intel compilers you require the following two components from Intel oneAPI, which have to be installed in the specified order:
+
+1. [Intel oneAPI Base Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html?operatingsystem=mac&distributions=online)
+2. [Intel oneAPI HPC Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit-download.html?operatingsystem=mac&distributions=online)


### PR DESCRIPTION
Adding instructions for the right setup of the Intel oneAPI toolkit for which we need to install

* Base Toolkit
* HPC Toolkit